### PR TITLE
Fix JavaAgent to work with both java6 and java7

### DIFF
--- a/src/main/java/org/robotframework/remoteswinglibrary/agent/JavaAgent.java
+++ b/src/main/java/org/robotframework/remoteswinglibrary/agent/JavaAgent.java
@@ -97,10 +97,8 @@ public class JavaAgent {
         public boolean hasWindow(AppContext ctx) {
             Vector<WeakReference<Window>> windowList =
                   (Vector<WeakReference<Window>>)ctx.get(Window.class);
-            if (windowList == null)
+            if (windowList == null || windowList.size() < 1)
                 return false;
-		    if (windowList.size() < 1)
-				return false;
             if (windowList.get(0).get().getClass().getName().contains("ConsoleWindow"))
                 return false;
 			return true;


### PR DESCRIPTION
Fix components name to work with Java6 and Java7.
Add if statements to properly find AppContext.
