### PR TITLE
Sleep in premain to prevent findAppContext thread from dying

### DIFF
--- a/src/main/java/org/robotframework/remoteswinglibrary/agent/JavaAgent.java
+++ b/src/main/java/org/robotframework/remoteswinglibrary/agent/JavaAgent.java
@@ -34,6 +34,9 @@ public class JavaAgent {
             Thread findAppContext = new Thread(new FindAppContextWithWindow(host, port, debug));
             findAppContext.setDaemon(true);
             findAppContext.start();
+            // Sleep to ensure that findAppContext daemon thread is kept alive until the
+            // application is started.
+            Thread.sleep(1000);
         } catch (Exception e) {
             e.printStackTrace();
             System.err.println(e);


### PR DESCRIPTION
We have been troubleshooting the situation where finding a particular application launched with Java WebStart frequently fails. Studying the debug output with some of our custom additions would indicate that findAppContext daemon thread is sometimes prematurely killed by the JVM, and thus the application is not found by the remoteswinglibrary.

The correction is partly a lucky guess, but there hasn't been a single launch failure in our own test environment since the correction was put there.