### PR TITLE
Accept security dialogs

### DIFF
--- a/src/main/java/org/robotframework/remoteswinglibrary/agent/FindAppContextWithWindow.java
+++ b/src/main/java/org/robotframework/remoteswinglibrary/agent/FindAppContextWithWindow.java
@@ -141,7 +141,6 @@ class FindAppContextWithWindow implements Runnable {
             try {
                 String title = dialog.getTitle();
                 SwingLibrary lib = new SwingLibrary();
-                //System.err.println("DIALOG TITLE IS:: " + title);
                 if (title.equals("Security Warning")) {
                     SecurityWarning(lib);
                     LogSuccess(dialog);
@@ -172,7 +171,6 @@ class FindAppContextWithWindow implements Runnable {
 
         private void SecurityWarning(SwingLibrary lib) {
             lib.runKeyword("select_dialog", new Object[]{"Security Warning"});
-            //lib.runKeyword("push_button", new Object[]{"DoES not exists"});
             String buttonText = (String) lib.runKeyword("get_button_text", new Object[]{"1"});
             System.err.println("button name is: " + buttonText);
             if (buttonText.equals("Run")) {
@@ -186,13 +184,11 @@ class FindAppContextWithWindow implements Runnable {
 
         private void SecurityInformation(SwingLibrary lib) {
             lib.runKeyword("select_dialog", new Object[]{"Security Information"});
-            //lib.runKeyword("check_check_box", new Object[]{"0"});
             lib.runKeyword("push_button", new Object[]{"Run"});
         }
 
         private void InstallJavaExtentension(SwingLibrary lib) {
             lib.runKeyword("select_dialog", new Object[]{"Install Java Extension"});
-            //lib.runKeyword("check_check_box", new Object[]{"0"});
             lib.runKeyword("push_button", new Object[]{"Install"});
         }
     }

--- a/src/main/java/org/robotframework/remoteswinglibrary/agent/FindAppContextWithWindow.java
+++ b/src/main/java/org/robotframework/remoteswinglibrary/agent/FindAppContextWithWindow.java
@@ -70,7 +70,7 @@ class FindAppContextWithWindow implements Runnable {
             for (Map.Entry<Dialog, SecurityDialogAccepter> entry: dialogs.entrySet()) {
                 Dialog dialog = entry.getKey();
                 SecurityDialogAccepter accepter = entry.getValue();
-                if (accepter.attempts > 0 && !accepter.running) {
+                if (accepter.attempts > 0 && !accepter.running && !accepter.done) {
                     accepter.running = true;
                     sun.awt.SunToolkit.invokeLaterOnAppContext(accepter.ctx, accepter);
                 }
@@ -130,6 +130,7 @@ class FindAppContextWithWindow implements Runnable {
         public Dialog dialog;
         private RobotConnection robotConnection;
         public int attempts = 5;
+        public boolean done = false;
 
         public SecurityDialogAccepter(Dialog dialog, AppContext ctx, RobotConnection robotConnection) {
             this.dialog = dialog;
@@ -167,6 +168,7 @@ class FindAppContextWithWindow implements Runnable {
         private void LogSuccess(Dialog dialog) {
             System.err.println(String.format("Security Warning Dialog '%s' has been accepted", dialog.getTitle()));
             //robotConnection.send("DIALOG:" + dialog.getTitle());
+            this.done = true;
         }
 
         private void SecurityWarning(SwingLibrary lib) {

--- a/src/main/java/org/robotframework/remoteswinglibrary/agent/FindAppContextWithWindow.java
+++ b/src/main/java/org/robotframework/remoteswinglibrary/agent/FindAppContextWithWindow.java
@@ -33,6 +33,7 @@ class FindAppContextWithWindow implements Runnable {
     int port;
     boolean debug;
     boolean closeSecurityDialogs;
+    RobotConnection robotConnection;
 
     HashMap<Dialog, SecurityDialogAccepter> dialogs = new HashMap<Dialog, SecurityDialogAccepter>();
 
@@ -45,7 +46,10 @@ class FindAppContextWithWindow implements Runnable {
 
     public void run()  {
         try {
-            sun.awt.SunToolkit.invokeLaterOnAppContext(getAppContextWithWindow(), new ServerThread(host, port, debug));
+            robotConnection = new RobotConnection(host, port);
+            robotConnection.connect();
+            AppContext appContext = getAppContextWithWindow();
+            sun.awt.SunToolkit.invokeLaterOnAppContext(appContext, new ServerThread(robotConnection, debug));
         } catch (Exception e) {
             if (debug) {
                 e.printStackTrace();

--- a/src/main/java/org/robotframework/remoteswinglibrary/agent/FindAppContextWithWindow.java
+++ b/src/main/java/org/robotframework/remoteswinglibrary/agent/FindAppContextWithWindow.java
@@ -70,7 +70,7 @@ class FindAppContextWithWindow implements Runnable {
             for (Map.Entry<Dialog, SecurityDialogAccepter> entry: dialogs.entrySet()) {
                 Dialog dialog = entry.getKey();
                 SecurityDialogAccepter accepter = entry.getValue();
-                if (!accepter.done && !accepter.running) {
+                if (accepter.attempts > 0 && !accepter.running) {
                     accepter.running = true;
                     sun.awt.SunToolkit.invokeLaterOnAppContext(accepter.ctx, accepter);
                 }
@@ -126,10 +126,10 @@ class FindAppContextWithWindow implements Runnable {
     private class SecurityDialogAccepter implements Runnable {
 
         public boolean running = false;
-        public boolean done = false;
         private AppContext ctx;
         public Dialog dialog;
         private RobotConnection robotConnection;
+        public int attempts = 5;
 
         public SecurityDialogAccepter(Dialog dialog, AppContext ctx, RobotConnection robotConnection) {
             this.dialog = dialog;
@@ -156,12 +156,12 @@ class FindAppContextWithWindow implements Runnable {
                 }
                 else
                     System.err.println("Unrecognized dialog, skipping.");
-                done = true;
             } catch (Throwable t) {
                 System.err.println(String.format("Accepting Security Warning Dialog '%s' has failed.",
                         dialog.getTitle()));
             }
             running = false;
+            attempts--;
         }
 
 

--- a/src/main/java/org/robotframework/remoteswinglibrary/agent/FindAppContextWithWindow.java
+++ b/src/main/java/org/robotframework/remoteswinglibrary/agent/FindAppContextWithWindow.java
@@ -32,13 +32,15 @@ class FindAppContextWithWindow implements Runnable {
     String host;
     int port;
     boolean debug;
+    boolean closeSecurityDialogs;
 
     HashMap<Dialog, SecurityDialogAccepter> dialogs = new HashMap<Dialog, SecurityDialogAccepter>();
 
-    public FindAppContextWithWindow(String host, int port, boolean debug) {
+    public FindAppContextWithWindow(String host, int port, boolean debug, boolean closeSecurityDialogs) {
         this.host = host;
         this.port = port;
         this.debug = debug;
+        this.closeSecurityDialogs = closeSecurityDialogs;
     }
 
     public void run()  {
@@ -84,7 +86,7 @@ class FindAppContextWithWindow implements Runnable {
         for (WeakReference<Window> ref:windowList) {
             Window window = ref.get();
             if (debug) logWindowDetails("Trying to connect to", window);
-            if (window instanceof Dialog) {
+            if (closeSecurityDialogs && window instanceof Dialog) {
                 Dialog dialog = (Dialog) window;
                 if (!dialogs.containsKey(dialog)) {
                     SecurityDialogAccepter accepter = new SecurityDialogAccepter(dialog, ctx);
@@ -152,6 +154,7 @@ class FindAppContextWithWindow implements Runnable {
         private void SecurityWarning() {
             SwingLibrary lib = new SwingLibrary();
             lib.runKeyword("select_dialog", new Object[]{"Security Warning"});
+            //lib.runKeyword("push_button", new Object[]{"DoES not exists"});
             String buttonText = (String) lib.runKeyword("get_button_text", new Object[]{"1"});
             System.err.println("button name is: " + buttonText);
             if (buttonText.equals("Run")) {

--- a/src/main/java/org/robotframework/remoteswinglibrary/agent/JavaAgent.java
+++ b/src/main/java/org/robotframework/remoteswinglibrary/agent/JavaAgent.java
@@ -19,6 +19,7 @@ package org.robotframework.remoteswinglibrary.agent;
 
 import javax.swing.*;
 import java.lang.instrument.Instrumentation;
+import java.util.Arrays;
 
 
 public class JavaAgent {
@@ -29,9 +30,10 @@ public class JavaAgent {
         String[] args = agentArgument.split(":");
         String host = args[0];
         int port = getRemoteSwingLibraryPort(args[1]);
-        boolean debug = args.length > 2 && args[2].equals("DEBUG");
+        boolean debug = Arrays.asList(args).contains("DEBUG");
+        boolean closeSecurityDialogs = Arrays.asList(args).contains("CLOSE_SECURITY_DIALOGS");
         try {
-            Thread findAppContext = new Thread(new FindAppContextWithWindow(host, port, debug));
+            Thread findAppContext = new Thread(new FindAppContextWithWindow(host, port, debug, closeSecurityDialogs));
             findAppContext.setDaemon(true);
             findAppContext.start();
             // Sleep to ensure that findAppContext daemon thread is kept alive until the

--- a/src/main/java/org/robotframework/remoteswinglibrary/agent/RobotConnection.java
+++ b/src/main/java/org/robotframework/remoteswinglibrary/agent/RobotConnection.java
@@ -21,9 +21,13 @@ public class RobotConnection {
         outToServer = new PrintWriter(echoSocket.getOutputStream(), true);
     }
 
-    public void close() throws IOException {
-        outToServer.close();
-        echoSocket.close();
+    public void close() {
+        try {
+            outToServer.close();
+            echoSocket.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 
     public void send(String msg) {

--- a/src/main/java/org/robotframework/remoteswinglibrary/agent/RobotConnection.java
+++ b/src/main/java/org/robotframework/remoteswinglibrary/agent/RobotConnection.java
@@ -1,0 +1,32 @@
+package org.robotframework.remoteswinglibrary.agent;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.Socket;
+
+public class RobotConnection {
+
+    String host;;
+    int port;
+    Socket echoSocket;
+    PrintWriter outToServer;
+
+    public RobotConnection(String host, int port) {
+        this.host = host;
+        this.port = port;
+    }
+
+    public void connect() throws IOException {
+        echoSocket = new Socket(host, port);
+        outToServer = new PrintWriter(echoSocket.getOutputStream(), true);
+    }
+
+    public void close() throws IOException {
+        outToServer.close();
+        echoSocket.close();
+    }
+
+    public void send(String msg) {
+        outToServer.write(msg + "\n");
+    }
+}

--- a/src/main/java/org/robotframework/remoteswinglibrary/agent/ServerThread.java
+++ b/src/main/java/org/robotframework/remoteswinglibrary/agent/ServerThread.java
@@ -55,7 +55,6 @@ public class ServerThread implements Runnable {
 
     private void notifyPort(final Integer portToNotify) throws IOException {
         robotConnection.connect();
-        //robotConnection.send("DIALOG:" + "aaa");
         robotConnection.send("PORT:" + portToNotify.toString() + ":" + getName());
         robotConnection.close();
     }

--- a/src/main/java/org/robotframework/remoteswinglibrary/agent/ServerThread.java
+++ b/src/main/java/org/robotframework/remoteswinglibrary/agent/ServerThread.java
@@ -54,7 +54,9 @@ public class ServerThread implements Runnable {
     }
 
     private void notifyPort(final Integer portToNotify) throws IOException {
-        robotConnection.send(portToNotify.toString() + ":" + getName());
+        robotConnection.connect();
+        //robotConnection.send("DIALOG:" + "aaa");
+        robotConnection.send("PORT:" + portToNotify.toString() + ":" + getName());
         robotConnection.close();
     }
 

--- a/src/main/java/org/robotframework/remoteswinglibrary/agent/ServerThread.java
+++ b/src/main/java/org/robotframework/remoteswinglibrary/agent/ServerThread.java
@@ -21,20 +21,16 @@ import org.robotframework.remoteswinglibrary.remote.DaemonRemoteServer;
 import org.robotframework.swing.SwingLibrary;
 
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.net.Socket;
 import java.util.Map;
 
 
 public class ServerThread implements Runnable {
 
-    String host;
-    int port;
     boolean debug;
+    RobotConnection robotConnection;
 
-    public ServerThread(String host, int port, boolean debug) {
-        this.host = host;
-        this.port = port;
+    public ServerThread(RobotConnection robotConnection, boolean debug) {
+        this.robotConnection = robotConnection;
         this.debug = debug;
     }
 
@@ -47,7 +43,7 @@ public class ServerThread implements Runnable {
             server.setAllowStop(true);
             server.start();
             Integer actualPort = server.getLocalPort();
-            notifyPort(actualPort, host, port);
+            notifyPort(actualPort);
         } catch (Exception e) {
             if (debug) {
                 e.printStackTrace();
@@ -57,12 +53,9 @@ public class ServerThread implements Runnable {
         }
     }
 
-    private static void notifyPort(final Integer portToNotify, final String serverHost, final Integer serverPort) throws IOException {
-        Socket echoSocket = new Socket(serverHost, serverPort);
-        PrintWriter outToServer = new PrintWriter(echoSocket.getOutputStream(), true);
-        outToServer.write(portToNotify.toString() + ":" + getName());
-        outToServer.close();
-        echoSocket.close();
+    private void notifyPort(final Integer portToNotify) throws IOException {
+        robotConnection.send(portToNotify.toString() + ":" + getName());
+        robotConnection.close();
     }
 
     private static String getName() {

--- a/src/main/python/RemoteSwingLibrary.py
+++ b/src/main/python/RemoteSwingLibrary.py
@@ -203,7 +203,7 @@ class RemoteSwingLibrary(object):
     AGENT_PATH = os.path.abspath(os.path.dirname(__file__))
     _output_dir = ''
 
-    def __init__(self, port=None, debug=False):
+    def __init__(self, port=None, debug=False, close_security_dialogs=False):
         """
         *port*: optional port for the server receiving connections from remote agents
 
@@ -214,7 +214,7 @@ class RemoteSwingLibrary(object):
         """
         if RemoteSwingLibrary.PORT is None:
             RemoteSwingLibrary.PORT = self._start_port_server(0 if port == 'TEST' else port or 0)
-        self._create_env(bool(debug), port != 'TEST')
+        self._create_env(bool(debug), port != 'TEST', close_security_dialogs=bool(close_security_dialogs))
         if port == 'TEST':
             self.start_application('docgenerator', 'java -jar %s' % RemoteSwingLibrary.AGENT_PATH, timeout=4.0)
 
@@ -234,10 +234,12 @@ class RemoteSwingLibrary(object):
         t.start()
         return server.server_address[1]
 
-    def _create_env(self, debug, robot_running=True):
+    def _create_env(self, debug, robot_running=True, close_security_dialogs=False):
         agent_command = '-javaagent:"%s"=127.0.0.1:%s' % (RemoteSwingLibrary.AGENT_PATH, RemoteSwingLibrary.PORT)
         if debug:
             agent_command += ':DEBUG'
+        if close_security_dialogs:
+            agent_command += ':CLOSE_SECURITY_DIALOGS'
         self._agent_command = agent_command
         if robot_running:
             BuiltIn().set_global_variable('\${REMOTESWINGLIBRARYPATH}', self._escape_path(RemoteSwingLibrary.AGENT_PATH))

--- a/src/main/python/RemoteSwingLibrary.py
+++ b/src/main/python/RemoteSwingLibrary.py
@@ -72,12 +72,22 @@ REMOTE_AGENTS_LIST = AgentList()
 class SimpleServer(SocketServer.StreamRequestHandler):
 
     def handle(self):
-        data = self.rfile.readline().strip()
-        port, name = data.decode().split(':', 1)
-        address = ':'.join([self.client_address[0], port])
-        logger.debug('Registered java remoteswinglibrary agent "%s" at %s' % \
-              (name, address))
-        REMOTE_AGENTS_LIST.append(address, name)
+        data = self.rfile.readline()[:-1]
+        #logger.debug("DATA: " + data)
+        fields = data.decode().split(':')
+        if fields[0] == 'PORT':
+            port = fields[1]
+            name = ':'.join(fields[2:])
+            address = ':'.join([self.client_address[0], port])
+            logger.debug('Registered java remoteswinglibrary agent "%s" at %s' % \
+                         (name, address))
+            REMOTE_AGENTS_LIST.append(address, name)
+            self.request.sendall(data)
+        elif fields[0] == 'DIALOG':
+            title = ':'.join(fields[1:])
+            logger.info('Security Warning "%s" was accepted automatically' % title)
+        else:
+            logger.debug('Unknown message "%s"' % fields[0])
 
 
 class InvalidURLException(Exception):

--- a/src/main/python/RemoteSwingLibrary.py
+++ b/src/main/python/RemoteSwingLibrary.py
@@ -224,6 +224,7 @@ class RemoteSwingLibrary(object):
         self._create_env(bool(debug), port != 'TEST', close_security_dialogs=bool(close_security_dialogs))
         if port == 'TEST':
             self.start_application('docgenerator', 'java -jar %s' % RemoteSwingLibrary.AGENT_PATH, timeout=4.0)
+        logger.warn("INIT %s" % self._agent_command)
 
     @property
     def current(self):

--- a/src/main/python/RemoteSwingLibrary.py
+++ b/src/main/python/RemoteSwingLibrary.py
@@ -82,7 +82,7 @@ class SimpleServer(SocketServer.StreamRequestHandler):
             logger.debug('Registered java remoteswinglibrary agent "%s" at %s' % \
                          (name, address))
             REMOTE_AGENTS_LIST.append(address, name)
-            self.request.sendall(data)
+            #self.request.sendall(data)
         elif fields[0] == 'DIALOG':
             title = ':'.join(fields[1:])
             logger.info('Security Warning "%s" was accepted automatically' % title)
@@ -235,8 +235,10 @@ class RemoteSwingLibrary(object):
         address = ('0.0.0.0', int(port))
         server = SocketServer.TCPServer(address, SimpleServer)
         server.allow_reuse_address = True
+        #t = threading.Thread(name="RemoteSwingLibrary registration server thread",
+        #                     target=server.serve_forever)
         t = threading.Thread(name="RemoteSwingLibrary registration server thread",
-                             target=server.serve_forever)
+                             target=server.serve_forever, args=(0.01,))
         t.setDaemon(True)
         t.start()
         return server.server_address[1]

--- a/src/main/python/RemoteSwingLibrary.py
+++ b/src/main/python/RemoteSwingLibrary.py
@@ -121,13 +121,18 @@ class OldRobotImporterWrapper(_RobotImporterWrapper):
 class RobotLibraryImporter(object):
     """Class for manipulating Robot Framework library imports during runtime"""
 
+    args = ()
+
+    def set_args(self, port=None, debug=False, close_security_dialogs=False):
+        self.args = (port, debug, close_security_dialogs)
+
     def re_import_remoteswinglibrary(self):
         if EXECUTION_CONTEXTS.current is None:
             return
         name = 'RemoteSwingLibrary'
         self._remove_lib_from_current_namespace(name)
         self._import_wrapper().remove_library(name, [])
-        BuiltIn().import_library(name)
+        BuiltIn().import_library(name, *self.args)
 
     def _import_wrapper(self):
         if hasattr(IMPORTER, '_library_cache'):
@@ -219,6 +224,7 @@ class RemoteSwingLibrary(object):
         NOTE! with special value 'TEST' starts a test application for documentation generation
         purposes `python -m robot.libdoc RemoteSwingLibrary::TEST RemoteSwingLibrary.html`
         """
+        self.ROBOT_NAMESPACE_BRIDGE.set_args(port, debug, close_security_dialogs)
         if RemoteSwingLibrary.PORT is None:
             RemoteSwingLibrary.PORT = self._start_port_server(0 if port == 'TEST' else port or 0)
         self._create_env(bool(debug), port != 'TEST', close_security_dialogs=bool(close_security_dialogs))

--- a/src/main/python/RemoteSwingLibrary.py
+++ b/src/main/python/RemoteSwingLibrary.py
@@ -214,6 +214,8 @@ class RemoteSwingLibrary(object):
 
         *debug*: optional flag that will start agent in mode with more logging for troubleshooting (set to TRUE to enable)
 
+        *close_security_dialogs*: optional flag for automatic security dialogs closing (set to TRUE to enable)
+
         NOTE! with special value 'TEST' starts a test application for documentation generation
         purposes `python -m robot.libdoc RemoteSwingLibrary::TEST RemoteSwingLibrary.html`
         """

--- a/src/main/python/RemoteSwingLibrary.py
+++ b/src/main/python/RemoteSwingLibrary.py
@@ -230,7 +230,6 @@ class RemoteSwingLibrary(object):
         self._create_env(bool(debug), port != 'TEST', close_security_dialogs=bool(close_security_dialogs))
         if port == 'TEST':
             self.start_application('docgenerator', 'java -jar %s' % RemoteSwingLibrary.AGENT_PATH, timeout=4.0)
-        logger.warn("INIT %s" % self._agent_command)
 
     @property
     def current(self):

--- a/src/main/python/RemoteSwingLibrary.py
+++ b/src/main/python/RemoteSwingLibrary.py
@@ -73,7 +73,6 @@ class SimpleServer(SocketServer.StreamRequestHandler):
 
     def handle(self):
         data = self.rfile.readline()[:-1]
-        #logger.debug("DATA: " + data)
         fields = data.decode().split(':')
         if fields[0] == 'PORT':
             port = fields[1]
@@ -82,7 +81,6 @@ class SimpleServer(SocketServer.StreamRequestHandler):
             logger.debug('Registered java remoteswinglibrary agent "%s" at %s' % \
                          (name, address))
             REMOTE_AGENTS_LIST.append(address, name)
-            #self.request.sendall(data)
         elif fields[0] == 'DIALOG':
             title = ':'.join(fields[1:])
             logger.info('Security Warning "%s" was accepted automatically' % title)

--- a/src/main/python/RemoteSwingLibrary.py
+++ b/src/main/python/RemoteSwingLibrary.py
@@ -69,18 +69,15 @@ class AgentList(object):
 
 REMOTE_AGENTS_LIST = AgentList()
 
-class SimpleServer(SocketServer.BaseRequestHandler):
+class SimpleServer(SocketServer.StreamRequestHandler):
 
     def handle(self):
-        data = ''.join(iter(self.read_socket, ''))
+        data = self.rfile.readline().strip()
         port, name = data.decode().split(':', 1)
         address = ':'.join([self.client_address[0], port])
         logger.debug('Registered java remoteswinglibrary agent "%s" at %s' % \
               (name, address))
         REMOTE_AGENTS_LIST.append(address, name)
-
-    def read_socket(self):
-        return self.request.recv(1)
 
 
 class InvalidURLException(Exception):

--- a/src/test/java/org/robotframework/remoteswinglibrary/SecurityDialogsApp.java
+++ b/src/test/java/org/robotframework/remoteswinglibrary/SecurityDialogsApp.java
@@ -1,0 +1,76 @@
+package org.robotframework.remoteswinglibrary;
+
+import javax.swing.*;
+
+
+public class SecurityDialogsApp extends JFrame {
+    public SecurityDialogsApp() {
+
+        super();
+        setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        pack();
+        SecurityWarningContiune();
+        SecurityWarningRun();
+        SecurityWarningInstall();
+        SecurityWarningWithCheckBox();
+
+        setVisible(true);
+    }
+
+    private void SecurityWarningContiune() {
+        Object[] options = {"Continue", "Cancel"};
+        int n = JOptionPane.showOptionDialog(this,
+                "Security Warning Dialog with continue button",
+                "Security Warning",
+                JOptionPane.YES_NO_CANCEL_OPTION,
+                JOptionPane.QUESTION_MESSAGE,
+                null,
+                options,
+                options[0]);
+    }
+
+    private void SecurityWarningRun() {
+        Object[] options = {"Run", "Cancel"};
+        int n = JOptionPane.showOptionDialog(this,
+                "Security Warning Dialog with run button",
+                "Security Information",
+                JOptionPane.YES_NO_CANCEL_OPTION,
+                JOptionPane.QUESTION_MESSAGE,
+                null,
+                options,
+                options[0]);
+    }
+
+    private void SecurityWarningInstall(){
+        Object[] options = {"Install", "Cancel"};
+        int n = JOptionPane.showOptionDialog(this,
+                "Security Warning Dialog with install button",
+                "Install Java Extension",
+                JOptionPane.YES_NO_CANCEL_OPTION,
+                JOptionPane.QUESTION_MESSAGE,
+                null,
+                options,
+                options[0]);
+    }
+
+    private void SecurityWarningWithCheckBox(){
+        JCheckBox rememberChk = new JCheckBox("I accept the risk and want to run this application.");
+        JButton moreInfoButton = new JButton("More Information");
+        Object[] options = {"Run",
+                "Cancel"};
+
+        Object[] msgContent = {"msg", moreInfoButton, rememberChk};
+        int n = JOptionPane.showOptionDialog(this,
+                msgContent,
+                "Security Warning",
+                JOptionPane.YES_NO_CANCEL_OPTION,
+                JOptionPane.QUESTION_MESSAGE,
+                null,
+                options,
+                options[0]);
+    }
+
+    public static void main(String[] a) {
+        SecurityDialogsApp myapp2 = new SecurityDialogsApp();
+    }
+}

--- a/src/test/robotframework/acceptance/remoteswinglibrary.robot
+++ b/src/test/robotframework/acceptance/remoteswinglibrary.robot
@@ -14,10 +14,6 @@ Starting and stopping application with main window
      Start Application    myapp2    java org.robotframework.remoteswinglibrary.MySwingApp  timeout=5 seconds
      System Exit
 
-Close Security Dialogs
-     Start Application  securityDialogsApp  java org.robotframework.remoteswinglibrary.MyApp2  timeout=5 seconds
-     System Exit
-
 Start application removes the JAVA_TOOL_OPTIONS from enviroment
      Set environment variable    JAVA_TOOL_OPTIONS   ${EMPTY}
      Start Application    myapp2    java org.robotframework.remoteswinglibrary.MySwingApp  timeout=5 seconds

--- a/src/test/robotframework/acceptance/remoteswinglibrary.robot
+++ b/src/test/robotframework/acceptance/remoteswinglibrary.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Library    RemoteSwingLibrary          debug=True
+Library    RemoteSwingLibrary          debug=True     close_security_dialogs=True
 Library    OperatingSystem
 Library    Process
 Suite setup    Set Environment Variable      CLASSPATH     target/test-classes

--- a/src/test/robotframework/acceptance/remoteswinglibrary.robot
+++ b/src/test/robotframework/acceptance/remoteswinglibrary.robot
@@ -1,4 +1,5 @@
 *** Settings ***
+
 Library    RemoteSwingLibrary          debug=True     close_security_dialogs=True
 Library    OperatingSystem
 Library    Process
@@ -11,6 +12,10 @@ None Existing Application start fails before timeout
 
 Starting and stopping application with main window
      Start Application    myapp2    java org.robotframework.remoteswinglibrary.MySwingApp  timeout=5 seconds
+     System Exit
+
+Close Security Dialogs
+     Start Application  securityDialogsApp  java org.robotframework.remoteswinglibrary.MyApp2  timeout=5 seconds
      System Exit
 
 Start application removes the JAVA_TOOL_OPTIONS from enviroment

--- a/src/test/robotframework/acceptance/security_dialogs.robot
+++ b/src/test/robotframework/acceptance/security_dialogs.robot
@@ -7,11 +7,11 @@ Suite setup    Set Environment Variable      CLASSPATH     target/test-classes
 
 *** Test Cases ***
 Close Security Dialogs
-     Start Application  securityDialogsApp  java org.robotframework.remoteswinglibrary.SecurityDialogsApp  timeout=60 seconds
+     Start Application  securityDialogsApp  java org.robotframework.remoteswinglibrary.SecurityDialogsApp  timeout=30 seconds
      System Exit
 
-Close Security Dialogs 2
-     Start Application  securityDialogsApp  java org.robotframework.remoteswinglibrary.SecurityDialogsApp  timeout=60 seconds
+Close Security Dialogs Again
+     Start Application  securityDialogsApp  java org.robotframework.remoteswinglibrary.SecurityDialogsApp  timeout=30 seconds
      System Exit
 
 *** Keywords ***

--- a/src/test/robotframework/acceptance/security_dialogs.robot
+++ b/src/test/robotframework/acceptance/security_dialogs.robot
@@ -1,0 +1,33 @@
+*** Settings ***
+
+Library    RemoteSwingLibrary          debug=True     close_security_dialogs=True
+Library    OperatingSystem
+Library    Process
+Suite setup    Set Environment Variable      CLASSPATH     target/test-classes
+
+*** Test Cases ***
+Close Security Dialogs
+     Start Application  securityDialogsApp  java org.robotframework.remoteswinglibrary.SecurityDialogsApp  timeout=60 seconds
+     System Exit
+
+Close Security Dialogs 2
+     Start Application  securityDialogsApp  java org.robotframework.remoteswinglibrary.SecurityDialogsApp  timeout=60 seconds
+     System Exit
+
+*** Keywords ***
+Keyword Should Not Exist
+   [Arguments]   ${keyword}
+   Run Keyword And Expect Error   No keyword with name '${keyword}' found.    Keyword Should Exist   ${keyword}
+
+Exit and check process
+   [Arguments]    ${handler}   ${alias}
+   Switch To Application  ${alias}
+   Process Should Be Running    ${handler}
+   System Exit
+   Wait until keyword succeeds   5 seconds   0.5 seconds   Process Should Be Stopped    ${handler}
+
+My Closing Keyword
+   [Arguments]    ${alias}
+   Switch To Application  ${alias}
+   Log     something plaah
+   System Exit

--- a/src/test/robotframework/acceptance/webstart.robot
+++ b/src/test/robotframework/acceptance/webstart.robot
@@ -1,5 +1,5 @@
  *** Settings ***
-Library    RemoteSwingLibrary        debug=True
+Library    RemoteSwingLibrary        debug=True   close_security_dialogs=True
 Library    FileServer
 Suite Setup     FileServer.Start
 Suite Teardown    FileServer.Stop


### PR DESCRIPTION
New feature closes security warning dialogs automatically. For now this feature is off by default, to enable it use `close_security_dialogs=True` when importing library.

TODO:
* documentation update
* ~~check if we also can close Java Update dialog~~ seems it's not possible
* ~~test application with mockup dialogs~~
* put screenshots of closed dialogs in log (maybe we can skip this feature for now)
* resolve issues with logging of closed windows