### PR TITLE
Reconnecting to open app

### DIFF
--- a/src/main/java/org/robotframework/remoteswinglibrary/agent/FindAppContextWithWindow.java
+++ b/src/main/java/org/robotframework/remoteswinglibrary/agent/FindAppContextWithWindow.java
@@ -31,15 +31,17 @@ class FindAppContextWithWindow implements Runnable {
 
     String host;
     int port;
+    int apport;
     boolean debug;
     boolean closeSecurityDialogs;
     RobotConnection robotConnection;
 
     HashMap<Dialog, SecurityDialogAccepter> dialogs = new HashMap<Dialog, SecurityDialogAccepter>();
 
-    public FindAppContextWithWindow(String host, int port, boolean debug, boolean closeSecurityDialogs) {
+    public FindAppContextWithWindow(String host, int port, int apport, boolean debug, boolean closeSecurityDialogs) {
         this.host = host;
         this.port = port;
+        this.apport = apport;
         this.debug = debug;
         this.closeSecurityDialogs = closeSecurityDialogs;
     }
@@ -49,7 +51,7 @@ class FindAppContextWithWindow implements Runnable {
             robotConnection = new RobotConnection(host, port);
             //robotConnection.connect();
             AppContext appContext = getAppContextWithWindow();
-            sun.awt.SunToolkit.invokeLaterOnAppContext(appContext, new ServerThread(robotConnection, debug));
+            sun.awt.SunToolkit.invokeLaterOnAppContext(appContext, new ServerThread(robotConnection, apport, debug));
         } catch (Exception e) {
             if (debug) {
                 e.printStackTrace();
@@ -85,8 +87,6 @@ class FindAppContextWithWindow implements Runnable {
               (Vector<WeakReference<Window>>)ctx.get(Window.class);
         if (windowList == null)
             return false;
-        // make a copy of the vector to prevent concurrency errors.
-        windowList = new Vector<WeakReference<Window>>(windowList);
         for (WeakReference<Window> ref:windowList) {
             Window window = ref.get();
             if (debug) logWindowDetails("Trying to connect to", window);

--- a/src/main/java/org/robotframework/remoteswinglibrary/agent/JavaAgent.java
+++ b/src/main/java/org/robotframework/remoteswinglibrary/agent/JavaAgent.java
@@ -32,8 +32,12 @@ public class JavaAgent {
         int port = getRemoteSwingLibraryPort(args[1]);
         boolean debug = Arrays.asList(args).contains("DEBUG");
         boolean closeSecurityDialogs = Arrays.asList(args).contains("CLOSE_SECURITY_DIALOGS");
+        int apport = 0;
+        for (String arg: args)
+            if (arg.startsWith("APPORT="))
+                apport = Integer.parseInt(arg.split("=")[1]);
         try {
-            Thread findAppContext = new Thread(new FindAppContextWithWindow(host, port, debug, closeSecurityDialogs));
+            Thread findAppContext = new Thread(new FindAppContextWithWindow(host, port, apport, debug, closeSecurityDialogs));
             findAppContext.setDaemon(true);
             findAppContext.start();
             // Sleep to ensure that findAppContext daemon thread is kept alive until the

--- a/src/main/java/org/robotframework/remoteswinglibrary/agent/ServerThread.java
+++ b/src/main/java/org/robotframework/remoteswinglibrary/agent/ServerThread.java
@@ -25,12 +25,13 @@ import java.util.Map;
 
 
 public class ServerThread implements Runnable {
-
+    int apport;
     boolean debug;
     RobotConnection robotConnection;
 
-    public ServerThread(RobotConnection robotConnection, boolean debug) {
+    public ServerThread(RobotConnection robotConnection,  int apport, boolean debug) {
         this.robotConnection = robotConnection;
+        this.apport = apport;
         this.debug = debug;
     }
 
@@ -39,7 +40,7 @@ public class ServerThread implements Runnable {
             RemoteServer server = new DaemonRemoteServer();
             server.putLibrary("/RPC2", new SwingLibrary());
             server.putLibrary("/services", new ServicesLibrary());
-            server.setPort(0);
+            server.setPort(apport);
             server.setAllowStop(true);
             server.start();
             Integer actualPort = server.getLocalPort();

--- a/src/test/robotframework/acceptance/existing_app/existingapp_1.robot
+++ b/src/test/robotframework/acceptance/existing_app/existingapp_1.robot
@@ -1,0 +1,9 @@
+*** Settings ***
+Library    RemoteSwingLibrary          apport=31337  debug=True
+Library    OperatingSystem
+Library    Process
+Suite setup    Set Environment Variable      CLASSPATH     target/test-classes
+
+*** Test Cases ***
+Starting application with main window
+     Start Application    myapp2    java org.robotframework.remoteswinglibrary.MySwingApp  timeout=5 seconds

--- a/src/test/robotframework/acceptance/existing_app/existingapp_2.robot
+++ b/src/test/robotframework/acceptance/existing_app/existingapp_2.robot
@@ -5,9 +5,6 @@ Library    Process
 Suite setup    Set Environment Variable      CLASSPATH     target/test-classes
 
 *** Test Cases ***
-Starting application with main window
-     Start Application    myapp2    java org.robotframework.remoteswinglibrary.MySwingApp  timeout=5 seconds
-
 Connecting to existing application on selected port and close it
-     Connect to application  myapp2    timeout=5 seconds
+     Connect to application    myapp2    timeout=5 seconds
      System Exit

--- a/src/test/robotframework/acceptance/existingapp.robot
+++ b/src/test/robotframework/acceptance/existingapp.robot
@@ -1,0 +1,13 @@
+*** Settings ***
+Library    RemoteSwingLibrary          apport=31337  debug=True
+Library    OperatingSystem
+Library    Process
+Suite setup    Set Environment Variable      CLASSPATH     target/test-classes
+
+*** Test Cases ***
+Starting application with main window
+     Start Application    myapp2    java org.robotframework.remoteswinglibrary.MySwingApp  timeout=5 seconds
+
+Connecting to existing application on selected port and close it
+     Connect to application  myapp2    timeout=5 seconds
+     System Exit


### PR DESCRIPTION
This is based on PR #20. I have rebased on up-to-date master also fixed problem which caused freeze between test suites in acceptance tests.

Reason for freeze was excessive waiting in `get_keyword_names`. Total waiting time for operation to timeout was about 30 minutes instead of expected 60 seconds. This change may also fix know issue when `Start Application` does not timeout in some circumstances when it has failed to connect to agent.

After I fixed that I discovered that in suite where RemoteSwingLibrary is imported with different settings state of library was not "clean" and this is why timeout happened in first place.

Solution is to handle two kinds of reimports differently: reimport which refresh keyword list after connecting to agent and reimport with different settings. Because RLS uses some static fields and a global variable (to keep state in first type of reimport), we need to reset them on second type of reimport.
