### PR TITLE
added log message when closing a security dialog (#49)

### DIFF
--- a/src/main/java/org/robotframework/remoteswinglibrary/agent/FindAppContextWithWindow.java
+++ b/src/main/java/org/robotframework/remoteswinglibrary/agent/FindAppContextWithWindow.java
@@ -46,7 +46,6 @@ class FindAppContextWithWindow implements Runnable {
     public void run()  {
         try {
             robotConnection = new RobotConnection(host, port);
-            //robotConnection.connect();
             AppContext appContext = getAppContextWithWindow();
             sun.awt.SunToolkit.invokeLaterOnAppContext(appContext, new ServerThread(robotConnection, apport, debug));
         } catch (Exception e) {
@@ -162,7 +161,9 @@ class FindAppContextWithWindow implements Runnable {
 
                     System.err.println(String.format("Security Warning Dialog '%s' has been accepted",
                             dialog.getTitle()));
-                    //robotConnection.send("DIALOG:" + dialog.getTitle());
+                    robotConnection.connect();
+                    robotConnection.send("DIALOG:" + title);
+                    robotConnection.close();
                     this.done = true;
                 }
                 else


### PR DESCRIPTION
This PR is a partial fix for issue #49. Partial because it doesn't contain the screenshot part.
 
All acceptance tests pass, didn't encounter any other issues.
@jussimalinen if you have time, can you please take a look at these changes?

Screen with the log message:
![log](https://cloud.githubusercontent.com/assets/4466614/25805122/29d22830-3407-11e7-8439-d950f66747cc.png)
