### PR TITLE
Fixes #60

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   </parent>
   <groupId>org.robotframework</groupId>
   <artifactId>remoteswinglibrary</artifactId>
-  <version>2.2.1</version>
+  <version>2.2.2</version>
   <packaging>jar</packaging>
 
   <name>robotframework-remoteswinglibrary</name>

--- a/src/main/java/org/robotframework/remoteswinglibrary/agent/FindAppContextWithWindow.java
+++ b/src/main/java/org/robotframework/remoteswinglibrary/agent/FindAppContextWithWindow.java
@@ -144,6 +144,7 @@ class FindAppContextWithWindow implements Runnable {
                 dialogTitles.add("Security Warning");
                 dialogTitles.add("Security Information");
                 dialogTitles.add("Install Java Extension");
+                dialogTitles.add("Sicherheitsinformationen");
 
                 String title = dialog.getTitle();
                 System.err.println(String.format("Handling Dialog '%s'.",
@@ -196,6 +197,7 @@ class FindAppContextWithWindow implements Runnable {
             acceptButtonList.add("Run");
             acceptButtonList.add("Continue");
             acceptButtonList.add("Install");
+            acceptButtonList.add("Ausführen");
 
             for (String text: acceptButtonList) {
                 try {

--- a/src/main/python/RemoteSwingLibrary.py
+++ b/src/main/python/RemoteSwingLibrary.py
@@ -283,7 +283,7 @@ class RemoteSwingLibrary(object):
         self._create_env(close_security_dialogs, remote_port)
         os.environ['JAVA_TOOL_OPTIONS'] = self._agent_command
         logger.debug("Set JAVA_TOOL_OPTIONS='%s'" % self._agent_command)
-        with tempfile.NamedTemporaryFile(prefix='grant_all_', suffix='.policy', delete=True) as t:
+        with tempfile.NamedTemporaryFile(prefix='grant_all_', suffix='.policy', delete=False) as t:
             text = b"""
                 grant {
                     permission java.security.AllPermission;

--- a/src/test/java/org/robotframework/remoteswinglibrary/SecurityDialogsApp.java
+++ b/src/test/java/org/robotframework/remoteswinglibrary/SecurityDialogsApp.java
@@ -14,6 +14,7 @@ public class SecurityDialogsApp extends JFrame {
         SecurityWarningRun();
         SecurityWarningInstall();
         SecurityWarningWithCheckBox();
+        SecurityWarningWithCheckBoxGerman();
 
         setVisible(true);
     }
@@ -64,6 +65,23 @@ public class SecurityDialogsApp extends JFrame {
         int n = JOptionPane.showOptionDialog(this,
                 msgContent,
                 "Security Warning",
+                JOptionPane.YES_NO_CANCEL_OPTION,
+                JOptionPane.QUESTION_MESSAGE,
+                null,
+                options,
+                options[0]);
+    }
+
+    private void SecurityWarningWithCheckBoxGerman(){
+        JCheckBox rememberChk = new JCheckBox("Für Anwendungen dieses Anbieters und aus diesem Speicherort nicht mehr anzeigen.");
+        JButton moreInfoButton = new JButton("Mehr Informationen");
+        Object[] options = {"Ausführen",
+                "Abbrechen"};
+
+        Object[] msgContent = {"msg", moreInfoButton, rememberChk};
+        int n = JOptionPane.showOptionDialog(this,
+                msgContent,
+                "Sicherheitsinformationen",
                 JOptionPane.YES_NO_CANCEL_OPTION,
                 JOptionPane.QUESTION_MESSAGE,
                 null,


### PR DESCRIPTION
I'm not quite sure why i had to change the delete-Argument in RemoteSwingLibrary.py#286 back to 'false' again. Without it i get permission denied exceptions when trying to launch the jar as a javaagent of a JNLP file.

Anyhow: This way it works with a german system as well.

Because I need the changes pretty fast I would appreciate if you could merge my changes and publish a new RemoteSwingLibrary to a public maven repository soon.

Thanks a lot. 