### PR TITLE
en-US locale when running JVM to avoid localization problems with security dialogs

### DIFF
--- a/src/main/python/RemoteSwingLibrary.py
+++ b/src/main/python/RemoteSwingLibrary.py
@@ -265,9 +265,10 @@ class RemoteSwingLibrary(object):
         policy for each java command call.
         """
         close_security_dialogs = _tobool(close_security_dialogs)
+        en_us_locale = "-Duser.language=en -Duser.country=US"
         self._create_env(close_security_dialogs, remote_port)
         os.environ['JAVA_TOOL_OPTIONS'] = self._agent_command
-        logger.debug("Set JAVA_TOOL_OPTIONS='%s'" % self._agent_command)
+        logger.debug("Set JAVA_TOOL_OPTIONS='%s %s'" % (en_us_locale, self._agent_command))
         with tempfile.NamedTemporaryFile(prefix='grant_all_', suffix='.policy', delete=False) as t:
             text = b"""
                 grant {


### PR DESCRIPTION
#61 

Wouldn't be better to use the JAVA_TOOL_OPTIONS to change the JVM locale? RemoteSwingLibrary already sets this environment variable to send the javaagent, and I think we should switch the locale to en-US there, rather than adding localisation support. 
