### PR TITLE
Replace deprecated inspect.getargspec

### DIFF
--- a/src/main/python/RemoteSwingLibrary.py
+++ b/src/main/python/RemoteSwingLibrary.py
@@ -630,7 +630,7 @@ class RemoteSwingLibrary(object):
         return swinglibrary.keyword_arguments[name]
 
     def _get_args(self, method_name):
-        spec = inspect.getargspec(getattr(self, method_name))
+        spec = inspect.getfullargspec(getattr(self, method_name))
         args = spec[0][1:]
         if spec[3]:
             for i, item in enumerate(reversed(spec[3])):


### PR DESCRIPTION
inspect.getargspec was deprecated since Python 3.0 and removed in Python 3.11 inspect.getfullargspec is its replacement